### PR TITLE
Get rid of errors in the modx log about division by zero

### DIFF
--- a/core/components/polls/model/polls/modpollanswer.class.php
+++ b/core/components/polls/model/polls/modpollanswer.class.php
@@ -9,7 +9,7 @@ class modPollAnswer extends xPDOSimpleObject
 	 */
 	public function getVotesPercent($total) {
 		
-		$percent = number_format(($this->votes / $total) * 100, 1, '.', '');
+		$percent = ($total > 0) ? number_format(($this->votes / $total) * 100, 1, '.', ''): 0;
 		
 		return $percent;
 	}


### PR DESCRIPTION
Small modification because the log file of modx was full of warnings about division by zero when ever there are no votes yet.
