### PR TITLE
Added option to get unique votes based on userid instead of ip-address

### DIFF
--- a/core/components/polls/elements/snippets/snippet.pollslatest.php
+++ b/core/components/polls/elements/snippets/snippet.pollslatest.php
@@ -26,6 +26,11 @@
  *
  * resultResource - (Opt) when set to a resource id, this resource will be used to show the poll results
  * resultLinkVar - (Opt) when using resultResource, this is the paramatername the snippet is looking for
+ *
+ * OPTIONS:
+ *
+ * uniqueBy - (Opt) defauls to ip, when set to user will limit voting to logged in users instead of ip-address
+ *
  */
 $polls = $modx->getService('polls','Polls',$modx->getOption('polls.core_path',null,$modx->getOption('core_path').'components/polls/').'model/polls/',$scriptProperties);
 if (!($polls instanceof Polls)) return '';
@@ -42,6 +47,7 @@ $sortby = $modx->getOption('sortby', $scriptProperties, 'id');
 $sortdir = $modx->getOption('sortdir', $scriptProperties, 'DESC');
 $resultResource = $modx->getOption('resultResource', $scriptProperties, null);
 $resultLinkVar = $modx->getOption('resultLinkVar', $scriptProperties, 'poll');
+$uniqueBy = $modx->getOption('uniqueBy', $scriptProperties, 'ip');
 
 // start getting latest poll
 $c = $modx->newQuery('modPollQuestion');
@@ -91,19 +97,29 @@ if(!empty($latest)) {
 	'idx' => $idx
       )
     );
-    $answersOutput .= $modx->getChunk((!$latest->hasVoted() ? $tplVoteAnswer : $tplResultAnswer), $answerParams);
+    $answersOutput .= $modx->getChunk((!$latest->hasVoted($uniqueBy) ? $tplVoteAnswer : $tplResultAnswer), $answerParams);
   }
   
   $placeholders['answers'] = $answersOutput;
   
-  if($latest->hasVoted()) {
+  if($latest->hasVoted($uniqueBy)) {
+	  
+	switch ($uniqueBy) {
+	    case 'user':
+	    	$user = $modx->getUser();
+	    	$vote = $latest->getOne('Logs', array('user:=' => $user->get(id)));
+			$placeholders['logdate'] = $vote->get('logdate');
+	    	break;
+	    default:
+	    	$vote = $latest->getOne('Logs', array('ipaddress:=' => $_SERVER['REMOTE_ADDR']));
+			$placeholders['logdate'] = $vote->get('logdate');
+	    	break;
+	}  
     
-    $vote = $latest->getOne('Logs', array('ipaddress:=' => $_SERVER['REMOTE_ADDR']));
-    $placeholders['logdate'] = $vote->get('logdate');
   }
   
   // build resource url for results if not has voted, because then the results are showed
-  if(!empty($resultResource) && is_numeric($resultResource) && $resultResource > 0 && !$latest->hasVoted()) {
+  if(!empty($resultResource) && is_numeric($resultResource) && $resultResource > 0 && !$latest->hasVoted($uniqueBy)) {
     
     $resource = $modx->getObject('modResource', $resultResource);
     
@@ -113,7 +129,7 @@ if(!empty($latest)) {
     }
   }
   
-  $output = $modx->getChunk((!$latest->hasVoted() ? $tplVote : $tplResult), $placeholders);
+  $output = $modx->getChunk((!$latest->hasVoted($uniqueBy) ? $tplVote : $tplResult), $placeholders);
   
   return $output;
 }

--- a/core/components/polls/model/polls/modpollanswer.class.php
+++ b/core/components/polls/model/polls/modpollanswer.class.php
@@ -43,10 +43,12 @@ class modPollAnswer extends xPDOSimpleObject
 	 * @return boolean
 	 */
 	private function logVote() {
+		$user = $this->xpdo->getUser();
 		
 		$vote = $this->xpdo->newObject('modPollLog');
 		$vote->set('question', $this->question);
 		$vote->set('ipaddress', $_SERVER['REMOTE_ADDR']);
+		$vote->set('user', $user->get('id'));
 		$vote->set('logdate', date('Y-m-d H:i:s'));
 		$vote->addOne($this);
 		
@@ -59,16 +61,29 @@ class modPollAnswer extends xPDOSimpleObject
 	}
 	
 	/**
-	 * Check if current IP address has voted on the current answer/question
+	 * Check if current IP address or logged in user has voted on the current answer/question
 	 *
 	 * @return boolean
 	 */
-	private function hasVoted() {
+	private function hasVoted($uniqueBy) {
 		
-		$vote = $this->getOne('Logs', array( 
-			'ipaddress:=' => $_SERVER['REMOTE_ADDR'],
-			'answer' => $this->id
-		));
+		switch ($uniqueBy) {
+			case 'user':
+				//retrieve userobject
+				$user = $this->xpdo->getUser();
+				
+				$vote = $this->getOne('Logs', array( 
+					'user:=' => $user->get('id'),
+					'answer' => $this->id
+				));
+				break;
+			default:
+				$vote = $this->getOne('Logs', array( 
+					'ipaddress:=' => $_SERVER['REMOTE_ADDR'],
+					'answer' => $this->id
+				));
+				break;
+		}
 		
 		if(!empty($vote)) {
 			

--- a/core/components/polls/model/polls/modpollquestion.class.php
+++ b/core/components/polls/model/polls/modpollquestion.class.php
@@ -47,16 +47,29 @@ class modPollQuestion extends xPDOSimpleObject
 	}
 	
 	/**
-	 * Checks if current visitor already has voted yet
+	 * Checks if current visitor already has voted yet (based on ipaddress or userid)
 	 *
 	 * @return boolean
 	 */
-	public function hasVoted() {
+	public function hasVoted($uniqueBy) {
 		
-		$vote = $this->getOne('Logs', array(
-			'ipaddress:=' => $_SERVER['REMOTE_ADDR'],
-			'question' => $this->id
-		));
+		switch ($uniqueBy) {
+			case 'user':
+				//retrieve userobject
+				$user = $this->xpdo->getUser();
+				
+				$vote = $this->getOne('Logs', array( 
+					'user:=' => $user->get('id'),
+					'question' => $this->id
+				));
+				break;
+			default:
+				$vote = $this->getOne('Logs', array(
+					'ipaddress:=' => $_SERVER['REMOTE_ADDR'],
+					'question' => $this->id
+				));
+				break;
+		}
 		
 		if(!empty($vote)) {
 			

--- a/core/components/polls/model/polls/mysql/modpolllog.map.inc.php
+++ b/core/components/polls/model/polls/mysql/modpolllog.map.inc.php
@@ -12,6 +12,7 @@ $xpdo_meta_map['modPollLog']= array (
     'question' => NULL,
     'answer' => NULL,
     'ipaddress' => NULL,
+    'user' => NULL,
     'logdate' => NULL,
   ),
   'fieldMeta' => 
@@ -35,6 +36,14 @@ $xpdo_meta_map['modPollLog']= array (
       'index' => 'index',
     ),
     'ipaddress' => 
+    array (
+      'dbtype' => 'varchar',
+      'precision' => '50',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'index',
+    ),
+    'user' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '50',

--- a/core/components/polls/model/schema/polls.mysql.schema.xml
+++ b/core/components/polls/model/schema/polls.mysql.schema.xml
@@ -33,6 +33,7 @@
 		<field key="question" dbtype="int" precision="11" attributes="unsigned" phptype="integer" null="false" index="index" />
 		<field key="answer" dbtype="int" precision="11" attributes="unsigned" phptype="integer" null="false" index="index" />
 		<field key="ipaddress" dbtype="varchar" precision="50" phptype="string" null="false" index="index" />
+		<field key="user" dbtype="varchar" precision="50" phptype="string" null="false" index="index" />
 		<field key="logdate" dbtype="datetime" phptype="datetime" null="false" />
 		
 		<aggregate alias="Question" class="modPollQuestion" local="answer" foreign="id" cardinality="one" owner="foreign" />


### PR DESCRIPTION
Usage: [[!Polls? &id=`1` &uniqueBy=`user` ]] or [[!PollsLatest? &uniqueBy=`user`]]

- fixed usage of undefined object $latest in Polls snippet, change to $poll
- added field 'user' to polls_answers table
- added userid to logging (defaults to 0 when not logged in)
- added option for Polls snippet and rewrote the check part
- added option for PollsLatest snippet and rewrote the check part
- added user to logVote() in modpollanswer.class.php
- rewrote hasVoted() in modpollanswer.class.php to handle with the option
- rewrote hasVoted() in modpollquestion.class.php to handle with the option